### PR TITLE
Push Claudix-Jetbrains

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "deps/roo-code"]
-	path = deps/roo-code
-	url = https://github.com/RooCodeInc/Roo-Code.git
 [submodule "deps/vscode"]
 	path = deps/vscode
 	url = https://github.com/microsoft/vscode.git

--- a/extension_host/package-lock.json
+++ b/extension_host/package-lock.json
@@ -145,6 +145,7 @@
         "ts-node": "^10.9.1",
         "tslib": "^2.6.3",
         "tsup": "^8.5.0",
+        "typescript": "^5.9.3",
         "util": "^0.12.4",
         "webpack": "^5.94.0",
         "webpack-cli": "^5.1.4",
@@ -446,6 +447,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1731,6 +1733,7 @@
       "integrity": "sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.1",
@@ -2834,6 +2837,7 @@
       "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3918,7 +3922,8 @@
       "version": "5.6.0-beta.114",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.6.0-beta.114.tgz",
       "integrity": "sha512-OW0Pz64qQU03xCv+56mscuxBeZH5cV7u4KrRrYxfFYn6VdbuY9pkWgR0yr5IfJ0lRfazVhZyzIo9/lm2uPPk4g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -4012,6 +4017,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4926,6 +4932,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -7447,6 +7454,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8018,6 +8026,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9515,6 +9524,7 @@
       "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob-watcher": "^5.0.3",
         "gulp-cli": "^2.2.0",
@@ -14237,6 +14247,7 @@
       "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",
@@ -16156,6 +16167,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16734,6 +16746,7 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -20044,6 +20057,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20330,7 +20344,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -20610,9 +20625,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -21271,6 +21286,7 @@
       "integrity": "sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -21320,6 +21336,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -21491,6 +21508,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/extension_host/package.json
+++ b/extension_host/package.json
@@ -10,7 +10,7 @@
     "dev": "tsc && node ./dist/src/main.js",
     "watch:tsc": "tsc --watch",
     "watch": "tsc --watch",
-    "build:extension": "tsc --noEmit && tsup"
+    "build:extension": "tsup"
   },
   "dependencies": {
     "@c4312/eventsource-umd": "^3.0.5",
@@ -151,6 +151,7 @@
     "ts-node": "^10.9.1",
     "tslib": "^2.6.3",
     "tsup": "^8.5.0",
+    "typescript": "^5.9.3",
     "util": "^0.12.4",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4",

--- a/extension_host/pnpm-lock.yaml
+++ b/extension_host/pnpm-lock.yaml
@@ -404,16 +404,19 @@ importers:
         version: 3.3.4(webpack@5.100.2)
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.2(typescript@4.9.5)(webpack@5.100.2)
+        version: 9.5.2(typescript@5.9.3)(webpack@5.100.2)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@20.19.9)(typescript@4.9.5)
+        version: 10.9.2(@types/node@20.19.9)(typescript@5.9.3)
       tslib:
         specifier: ^2.6.3
         version: 2.8.1
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(postcss@8.5.6)(typescript@4.9.5)
+        version: 8.5.0(postcss@8.5.6)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       util:
         specifier: ^0.12.4
         version: 0.12.5
@@ -5657,6 +5660,11 @@ packages:
   typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   typical@7.3.0:
@@ -11713,14 +11721,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-loader@9.5.2(typescript@4.9.5)(webpack@5.100.2):
+  ts-loader@9.5.2(typescript@5.9.3)(webpack@5.100.2):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.18.2
       micromatch: 4.0.8
       semver: 7.7.2
       source-map: 0.7.6
-      typescript: 4.9.5
+      typescript: 5.9.3
       webpack: 5.100.2(esbuild@0.25.8)(webpack-cli@5.1.4)
 
   ts-morph@25.0.1:
@@ -11728,7 +11736,7 @@ snapshots:
       '@ts-morph/common': 0.26.1
       code-block-writer: 13.0.3
 
-  ts-node@10.9.2(@types/node@20.19.9)(typescript@4.9.5):
+  ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -11742,7 +11750,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -11750,7 +11758,7 @@ snapshots:
 
   tsscmp@1.0.6: {}
 
-  tsup@8.5.0(postcss@8.5.6)(typescript@4.9.5):
+  tsup@8.5.0(postcss@8.5.6)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.8)
       cac: 6.7.14
@@ -11771,7 +11779,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.6
-      typescript: 4.9.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -11834,6 +11842,8 @@ snapshots:
   typedarray@0.0.6: {}
 
   typescript@4.9.5: {}
+
+  typescript@5.9.3: {}
 
   typical@7.3.0: {}
 

--- a/jetbrains_plugin/build.gradle.kts
+++ b/jetbrains_plugin/build.gradle.kts
@@ -60,11 +60,11 @@ kotlin {
 val ext = project.extensions.extraProperties
 ext.set("debugMode", findProperty("debugMode") ?: "none")
 ext.set("debugResource", project.projectDir.resolve("../debug-resources").absolutePath)
-ext.set("vscodePlugin", findProperty("vscodePlugin") ?: "roo-code")
+ext.set("vscodePlugin", findProperty("vscodePlugin") ?: "claudix")
 
 // Strongly-typed providers (avoid stringly-typed ext lookups during configuration)
 val debugModeProp = providers.gradleProperty("debugMode").orElse("none")
-val vscodePluginProp = providers.gradleProperty("vscodePlugin").orElse("roo-code")
+val vscodePluginProp = providers.gradleProperty("vscodePlugin").orElse("claudix")
 
 fun Sync.prepareSandbox() {
     // Read once during configuration; values also wired as task inputs below

--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/editor/EditorCommands.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/editor/EditorCommands.kt
@@ -83,6 +83,26 @@ fun registerOpenEditorAPICommands(project: Project,registry: CommandRegistry) {
             }
         }
     )
+
+    // Register testClaudixConfig command for debugging
+    registry.registerCommand(
+        object : ICommand{
+            override fun getId(): String {
+                return "_test.claudixConfig"
+            }
+            override fun getMethod(): String {
+                return "testClaudixConfig"
+            }
+
+            override fun handler(): Any {
+                return OpenEditorAPICommands(project)
+            }
+
+            override fun returns(): String? {
+                return "void"
+            }
+        }
+    )
 }
 
 /**
@@ -224,6 +244,41 @@ class OpenEditorAPICommands(val project: Project) {
         } else {
             logger.warn("No path provided for revealInExplorer")
         }
+        return null
+    }
+
+    /**
+     * Test Claudix configuration reading (for debugging)
+     *
+     * @return null
+     */
+    suspend fun testClaudixConfig(): Any? {
+        logger.info("[CLAUDIX-TEST] ========== Testing Claudix Configuration ==========")
+
+        try {
+            // 1. Test reading from ClaudixSettings
+            val settings = com.sina.weibo.agent.extensions.plugin.claudix.ClaudixSettings.getInstance()
+            val state = settings.state
+            logger.info("[CLAUDIX-TEST] From ClaudixSettings:")
+            logger.info("[CLAUDIX-TEST]   selectedModel: ${state.selectedModel}")
+            logger.info("[CLAUDIX-TEST]   environmentVariables count: ${state.environmentVariables.size}")
+            state.environmentVariables.forEachIndexed { index, envVar ->
+                logger.info("[CLAUDIX-TEST]   envVar[$index]: name=${envVar.name}, value=${envVar.value}")
+            }
+
+            // 2. Test reading from PropertiesComponent
+            val properties = com.intellij.ide.util.PropertiesComponent.getInstance()
+            val selectedModel = properties.getValue("claudix.selectedModel")
+            val envVarsJson = properties.getValue("claudix.environmentVariables")
+            logger.info("[CLAUDIX-TEST] From PropertiesComponent:")
+            logger.info("[CLAUDIX-TEST]   claudix.selectedModel: $selectedModel")
+            logger.info("[CLAUDIX-TEST]   claudix.environmentVariables: $envVarsJson")
+
+            logger.info("[CLAUDIX-TEST] ========== Test Complete ==========")
+        } catch (e: Exception) {
+            logger.error("[CLAUDIX-TEST] Failed to test Claudix configuration", e)
+        }
+
         return null
     }
 }

--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/extensions/plugin/claudix/ClaudixSettings.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/extensions/plugin/claudix/ClaudixSettings.kt
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package com.sina.weibo.agent.extensions.plugin.claudix
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+/**
+ * Claudix Settings State
+ *
+ * This matches the configuration in Claudix's package.json:
+ * - claudix.selectedModel: The AI model for Claude Code
+ * - claudix.environmentVariables: Environment variables to set when launching Claude
+ */
+data class ClaudixSettingsState(
+    var selectedModel: String = "default",
+    var environmentVariables: MutableList<EnvironmentVariable> = mutableListOf()
+)
+
+/**
+ * Environment Variable configuration
+ */
+data class EnvironmentVariable(
+    var name: String = "",
+    var value: String = ""
+)
+
+/**
+ * Claudix Settings Service
+ *
+ * Persists Claudix-specific configuration at the application level.
+ * These settings correspond to VSCode's claudix.* configuration entries.
+ */
+@Service(Service.Level.APP)
+@State(
+    name = "ClaudixSettings",
+    storages = [Storage("claudix-settings.xml")]
+)
+class ClaudixSettings : PersistentStateComponent<ClaudixSettingsState> {
+
+    private var state = ClaudixSettingsState()
+
+    override fun getState(): ClaudixSettingsState {
+        return state
+    }
+
+    override fun loadState(state: ClaudixSettingsState) {
+        XmlSerializerUtil.copyBean(state, this.state)
+    }
+
+    companion object {
+        /**
+         * Get the singleton instance of ClaudixSettings
+         */
+        fun getInstance(): ClaudixSettings {
+            return ApplicationManager.getApplication().getService(ClaudixSettings::class.java)
+        }
+    }
+}

--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/extensions/plugin/claudix/ClaudixSettingsConfigurable.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/extensions/plugin/claudix/ClaudixSettingsConfigurable.kt
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package com.sina.weibo.agent.extensions.plugin.claudix
+
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.options.Configurable
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.dsl.builder.*
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Claudix Settings Configurable
+ *
+ * Provides a UI for configuring Claudix-specific settings in the IDE Settings dialog.
+ * Maps to VSCode's Settings > Extensions > Claudix configuration.
+ */
+class ClaudixSettingsConfigurable : Configurable {
+
+    private val settings = ClaudixSettings.getInstance()
+    private var settingsPanel: JPanel? = null
+
+    // UI Components
+    private var selectedModelField: JBTextField? = null
+    private val envVarRows = mutableListOf<Pair<JBTextField, JBTextField>>()
+
+    override fun getDisplayName(): String = "Claudix"
+
+    override fun createComponent(): JComponent {
+        val panel = panel {
+            group("Model Configuration") {
+                row("Selected Model:") {
+                    selectedModelField = textField()
+                        .comment("The AI model for Claude Code (e.g., claude-3-5-sonnet-20241022)")
+                        .component
+                }
+            }
+
+            group("Environment Variables") {
+                row {
+                    comment("Environment variables to set when launching Claude")
+                }
+
+                // Display existing environment variables
+                val state = settings.state
+                for (envVar in state.environmentVariables) {
+                    row {
+                        val nameField = textField()
+                            .label("Name:")
+                            .component
+                        nameField.text = envVar.name
+
+                        val valueField = textField()
+                            .label("Value:")
+                            .component
+                        valueField.text = envVar.value
+
+                        envVarRows.add(Pair(nameField, valueField))
+                    }
+                }
+
+                row {
+                    button("Add Variable") {
+                        // Add a new row for environment variable
+                        val nameField = JBTextField()
+                        val valueField = JBTextField()
+                        envVarRows.add(Pair(nameField, valueField))
+                        // Note: In a real implementation, you'd need to refresh the panel
+                        // For simplicity, this is a basic version
+                    }
+                }
+            }
+        }
+
+        settingsPanel = panel
+        return panel
+    }
+
+    override fun isModified(): Boolean {
+        val state = settings.state
+
+        // Check if selected model changed
+        if (selectedModelField?.text != state.selectedModel) {
+            return true
+        }
+
+        // Check if environment variables changed
+        if (envVarRows.size != state.environmentVariables.size) {
+            return true
+        }
+
+        for (i in envVarRows.indices) {
+            val (nameField, valueField) = envVarRows[i]
+            val envVar = state.environmentVariables.getOrNull(i)
+
+            if (envVar == null ||
+                nameField.text != envVar.name ||
+                valueField.text != envVar.value) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    override fun apply() {
+        val state = settings.state
+
+        // Update selected model
+        state.selectedModel = selectedModelField?.text ?: "default"
+
+        // Update environment variables
+        state.environmentVariables.clear()
+        for ((nameField, valueField) in envVarRows) {
+            val name = nameField.text?.trim() ?: ""
+            val value = valueField.text?.trim() ?: ""
+
+            if (name.isNotEmpty()) {
+                state.environmentVariables.add(
+                    EnvironmentVariable(name, value)
+                )
+            }
+        }
+
+        // Sync to PropertiesComponent so VSCode API can read the values
+        syncToPropertiesComponent()
+    }
+
+    /**
+     * Syncs ClaudixSettings to PropertiesComponent
+     * This allows VSCode's workspace.getConfiguration() API to access the values
+     */
+    private fun syncToPropertiesComponent() {
+        val properties = PropertiesComponent.getInstance()
+        val state = settings.state
+
+        // Sync selectedModel
+        properties.setValue("claudix.selectedModel", state.selectedModel)
+
+        // Sync environmentVariables as JSON-like string
+        val envVarsJson = state.environmentVariables.joinToString(",") {
+            "{\"name\":\"${it.name}\",\"value\":\"${it.value}\"}"
+        }
+        properties.setValue("claudix.environmentVariables", "[$envVarsJson]")
+    }
+
+    override fun reset() {
+        val state = settings.state
+
+        // Reset selected model field
+        selectedModelField?.text = state.selectedModel
+
+        // Reset environment variables
+        envVarRows.clear()
+        for (envVar in state.environmentVariables) {
+            val nameField = JBTextField(envVar.name)
+            val valueField = JBTextField(envVar.value)
+            envVarRows.add(Pair(nameField, valueField))
+        }
+    }
+
+    override fun disposeUIResources() {
+        settingsPanel = null
+        selectedModelField = null
+        envVarRows.clear()
+    }
+}

--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/extensions/plugin/claudix/ClaudixSettingsConfigurable.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/extensions/plugin/claudix/ClaudixSettingsConfigurable.kt
@@ -6,10 +6,15 @@ package com.sina.weibo.agent.extensions.plugin.claudix
 
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.options.Configurable
-import com.intellij.ui.components.JBTextField
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.table.JBTable
 import com.intellij.ui.dsl.builder.*
+import com.sina.weibo.agent.core.PluginContext
 import javax.swing.JComponent
 import javax.swing.JPanel
+import javax.swing.table.DefaultTableModel
 
 /**
  * Claudix Settings Configurable
@@ -21,18 +26,58 @@ class ClaudixSettingsConfigurable : Configurable {
 
     private val settings = ClaudixSettings.getInstance()
     private var settingsPanel: JPanel? = null
-
-    // UI Components
-    private var selectedModelField: JBTextField? = null
-    private val envVarRows = mutableListOf<Pair<JBTextField, JBTextField>>()
+    private var selectedModelField: com.intellij.ui.components.JBTextField? = null
+    private lateinit var envTableModel: DefaultTableModel
+    private lateinit var envTable: JBTable
 
     override fun getDisplayName(): String = "Claudix"
 
     override fun createComponent(): JComponent {
+        // 创建表格模型：两列（Name, Value）
+        envTableModel = object : DefaultTableModel(
+            arrayOf("Name", "Value"),
+            0
+        ) {
+            override fun isCellEditable(row: Int, column: Int): Boolean = true
+        }
+
+        // 从设置加载现有环境变量
+        val state = settings.state
+        for (envVar in state.environmentVariables) {
+            envTableModel.addRow(arrayOf(envVar.name, envVar.value))
+        }
+
+        // 创建表格
+        envTable = JBTable(envTableModel)
+
+        // 使用 ToolbarDecorator 包装表格,添加 +/- 按钮
+        val decorator = ToolbarDecorator.createDecorator(envTable)
+            .setAddAction {
+                // 点击 + 按钮时添加新行
+                envTableModel.addRow(arrayOf("", ""))
+                val newRow = envTableModel.rowCount - 1
+                envTable.setRowSelectionInterval(newRow, newRow)
+                envTable.editCellAt(newRow, 0)
+                envTable.transferFocus()
+            }
+            .setRemoveAction {
+                // 点击 - 按钮时删除选中行
+                val selectedRow = envTable.selectedRow
+                if (selectedRow >= 0) {
+                    envTableModel.removeRow(selectedRow)
+                }
+            }
+            .setRemoveActionUpdater {
+                // 只有选中行时才启用删除按钮
+                envTable.selectedRow >= 0
+            }
+            .disableUpDownActions() // 禁用上下移动按钮
+
         val panel = panel {
             group("Model Configuration") {
                 row("Selected Model:") {
                     selectedModelField = textField()
+                        .text(state.selectedModel)
                         .comment("The AI model for Claude Code (e.g., claude-3-5-sonnet-20241022)")
                         .component
                 }
@@ -42,35 +87,11 @@ class ClaudixSettingsConfigurable : Configurable {
                 row {
                     comment("Environment variables to set when launching Claude")
                 }
-
-                // Display existing environment variables
-                val state = settings.state
-                for (envVar in state.environmentVariables) {
-                    row {
-                        val nameField = textField()
-                            .label("Name:")
-                            .component
-                        nameField.text = envVar.name
-
-                        val valueField = textField()
-                            .label("Value:")
-                            .component
-                        valueField.text = envVar.value
-
-                        envVarRows.add(Pair(nameField, valueField))
-                    }
-                }
-
                 row {
-                    button("Add Variable") {
-                        // Add a new row for environment variable
-                        val nameField = JBTextField()
-                        val valueField = JBTextField()
-                        envVarRows.add(Pair(nameField, valueField))
-                        // Note: In a real implementation, you'd need to refresh the panel
-                        // For simplicity, this is a basic version
-                    }
-                }
+                    // 添加带工具栏的表格
+                    cell(decorator.createPanel())
+                        .align(Align.FILL)
+                }.resizableRow()
             }
         }
 
@@ -81,23 +102,25 @@ class ClaudixSettingsConfigurable : Configurable {
     override fun isModified(): Boolean {
         val state = settings.state
 
-        // Check if selected model changed
+        // 检查 selected model 是否修改
         if (selectedModelField?.text != state.selectedModel) {
             return true
         }
 
-        // Check if environment variables changed
-        if (envVarRows.size != state.environmentVariables.size) {
+        // 检查环境变量数量是否变化
+        if (envTableModel.rowCount != state.environmentVariables.size) {
             return true
         }
 
-        for (i in envVarRows.indices) {
-            val (nameField, valueField) = envVarRows[i]
+        // 检查每个环境变量是否修改
+        for (i in 0 until envTableModel.rowCount) {
+            val name = envTableModel.getValueAt(i, 0) as? String ?: ""
+            val value = envTableModel.getValueAt(i, 1) as? String ?: ""
             val envVar = state.environmentVariables.getOrNull(i)
 
             if (envVar == null ||
-                nameField.text != envVar.name ||
-                valueField.text != envVar.value) {
+                name != envVar.name ||
+                value != envVar.value) {
                 return true
             }
         }
@@ -108,15 +131,16 @@ class ClaudixSettingsConfigurable : Configurable {
     override fun apply() {
         val state = settings.state
 
-        // Update selected model
+        // 更新 selected model
         state.selectedModel = selectedModelField?.text ?: "default"
 
-        // Update environment variables
+        // 更新环境变量
         state.environmentVariables.clear()
-        for ((nameField, valueField) in envVarRows) {
-            val name = nameField.text?.trim() ?: ""
-            val value = valueField.text?.trim() ?: ""
+        for (i in 0 until envTableModel.rowCount) {
+            val name = (envTableModel.getValueAt(i, 0) as? String ?: "").trim()
+            val value = (envTableModel.getValueAt(i, 1) as? String ?: "").trim()
 
+            // 只保存非空的环境变量
             if (name.isNotEmpty()) {
                 state.environmentVariables.add(
                     EnvironmentVariable(name, value)
@@ -124,46 +148,123 @@ class ClaudixSettingsConfigurable : Configurable {
             }
         }
 
-        // Sync to PropertiesComponent so VSCode API can read the values
-        syncToPropertiesComponent()
+        // 同步到 MainThreadConfiguration (这会触发 VSCode API 的 config.update)
+        syncToMainThreadConfiguration()
     }
 
     /**
-     * Syncs ClaudixSettings to PropertiesComponent
-     * This allows VSCode's workspace.getConfiguration() API to access the values
+     * Syncs settings through MainThreadConfiguration and Extension Host RPC
+     * This triggers VSCode's workspace.getConfiguration().update() which persists to storage
      */
-    private fun syncToPropertiesComponent() {
-        val properties = PropertiesComponent.getInstance()
+    private fun syncToMainThreadConfiguration() {
         val state = settings.state
 
-        // Sync selectedModel
+        println("[CLAUDIX-DEBUG] ========== syncToMainThreadConfiguration START ==========")
+        println("[CLAUDIX-DEBUG] selectedModel: ${state.selectedModel}")
+        println("[CLAUDIX-DEBUG] environmentVariables count: ${state.environmentVariables.size}")
+        state.environmentVariables.forEachIndexed { index, envVar ->
+            println("[CLAUDIX-DEBUG] envVar[$index]: name=${envVar.name}, value=${envVar.value}")
+        }
+
+        // 1. Sync to PropertiesComponent (for JetBrains side storage)
+        val properties = PropertiesComponent.getInstance()
         properties.setValue("claudix.selectedModel", state.selectedModel)
 
-        // Sync environmentVariables as JSON-like string
         val envVarsJson = state.environmentVariables.joinToString(",") {
             "{\"name\":\"${it.name}\",\"value\":\"${it.value}\"}"
         }
         properties.setValue("claudix.environmentVariables", "[$envVarsJson]")
+        println("[CLAUDIX-DEBUG] Saved to PropertiesComponent")
+
+        // 2. Sync to Extension Host via RPC updateConfiguration
+        try {
+            // Find an active project to get PluginContext
+            val activeProject = getActiveProject()
+            println("[CLAUDIX-DEBUG] Active project: ${activeProject?.name}")
+
+            if (activeProject != null) {
+                val pluginContext = PluginContext.getInstance(activeProject)
+                val rpcProtocol = pluginContext.getRPCProtocol()
+
+                println("[CLAUDIX-DEBUG] RPC protocol available: ${rpcProtocol != null}")
+
+                if (rpcProtocol != null) {
+                    // Get ExtHostConfiguration proxy
+                    val extHostConfiguration = rpcProtocol.getProxy(
+                        com.sina.weibo.agent.core.ServiceProxyRegistry.ExtHostContext.ExtHostConfiguration
+                    )
+
+                    println("[CLAUDIX-DEBUG] Got ExtHostConfiguration proxy: $extHostConfiguration")
+
+                    // Build configuration model with Claudix settings
+                    val envVars = state.environmentVariables.map { envVar ->
+                        mapOf("name" to envVar.name, "value" to envVar.value)
+                    }
+
+                    val claudixConfig = mapOf(
+                        "claudix.selectedModel" to state.selectedModel,
+                        "claudix.environmentVariables" to envVars
+                    )
+
+                    println("[CLAUDIX-DEBUG] Built claudixConfig: $claudixConfig")
+
+                    val configModel = mapOf(
+                        "defaults" to mapOf(
+                            "contents" to claudixConfig,
+                            "keys" to claudixConfig.keys.toList(),
+                            "overrides" to emptyList<String>()
+                        ),
+                        "policy" to emptyMap<String, Any>(),
+                        "application" to emptyMap<String, Any>(),
+                        "userLocal" to emptyMap<String, Any>(),
+                        "userRemote" to emptyMap<String, Any>(),
+                        "workspace" to emptyMap<String, Any>(),
+                        "folders" to emptyList<Any>(),
+                        "configurationScopes" to emptyList<Any>()
+                    )
+
+                    println("[CLAUDIX-DEBUG] Calling extHostConfiguration.updateConfiguration()...")
+                    // Update configuration via RPC
+                    extHostConfiguration.updateConfiguration(configModel)
+                    println("[CLAUDIX-DEBUG] Successfully called updateConfiguration()")
+                    println("[CLAUDIX-DEBUG] Updated Claudix configuration via RPC: model=${state.selectedModel}, envVars=${envVars.size} items")
+                } else {
+                    println("[CLAUDIX-DEBUG] RPC protocol not available, Claudix configuration not synced to Extension Host")
+                }
+            } else {
+                println("[CLAUDIX-DEBUG] No active project found, Claudix configuration not synced to Extension Host")
+            }
+        } catch (e: Exception) {
+            println("[CLAUDIX-DEBUG] Failed to sync Claudix configuration to Extension Host: ${e.message}")
+            e.printStackTrace()
+        }
+
+        println("[CLAUDIX-DEBUG] ========== syncToMainThreadConfiguration END ==========")
+    }
+
+    /**
+     * Get the currently active project
+     */
+    private fun getActiveProject(): Project? {
+        val openProjects = ProjectManager.getInstance().openProjects
+        return openProjects.firstOrNull { it.isInitialized && !it.isDisposed }
     }
 
     override fun reset() {
         val state = settings.state
 
-        // Reset selected model field
+        // 重置 selected model 字段
         selectedModelField?.text = state.selectedModel
 
-        // Reset environment variables
-        envVarRows.clear()
+        // 重置环境变量表格
+        envTableModel.rowCount = 0
         for (envVar in state.environmentVariables) {
-            val nameField = JBTextField(envVar.name)
-            val valueField = JBTextField(envVar.value)
-            envVarRows.add(Pair(nameField, valueField))
+            envTableModel.addRow(arrayOf(envVar.name, envVar.value))
         }
     }
 
     override fun disposeUIResources() {
         settingsPanel = null
         selectedModelField = null
-        envVarRows.clear()
     }
 }

--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/ipc/proxy/interfaces/ExtHostConfigurationProxy.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/ipc/proxy/interfaces/ExtHostConfigurationProxy.kt
@@ -4,29 +4,10 @@
 
 package com.sina.weibo.agent.ipc.proxy.interfaces
 
-/**
- * Extension host configuration service interface
- * Corresponds to ExtHostConfiguration in VSCode
- */
 interface ExtHostConfigurationProxy {
-    /**
-     * Initialize configuration
-     * @param configModel Configuration model
-     */
     fun initializeConfiguration(configModel: Map<String, Any?>)
     
-    /**
-     * Update configuration
-     * @param configModel Configuration model
-     */
-    fun updateConfiguration(configModel: Map<String, Any?>)
+    fun acceptConfigurationChanged(data: Map<String, Any?>, change: Map<String, Any?>)
     
-    /**
-     * Get configuration
-     * @param key Configuration key
-     * @param section Configuration section
-     * @param scopeToLanguage Whether to scope to language
-     * @return Configuration value
-     */
     fun getConfiguration(key: String, section: String?, scopeToLanguage: Boolean): Any?
 } 

--- a/jetbrains_plugin/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains_plugin/src/main/resources/META-INF/plugin.xml
@@ -112,6 +112,14 @@ SPDX-License-Identifier: Apache-2.0
                     anchor="right" />
         <notificationGroup id="RunVSAgent"
                            displayType="BALLOON"/>
+
+        <!-- Claudix Settings -->
+        <applicationConfigurable
+            parentId="tools"
+            instance="com.sina.weibo.agent.extensions.plugin.claudix.ClaudixSettingsConfigurable"
+            id="com.sina.weibo.agent.extensions.plugin.claudix.ClaudixSettingsConfigurable"
+            displayName="Claudix"
+            groupId="tools" />
     </extensions>
 
     <extensions defaultExtensionNs="org.jetbrains.plugins.terminal">


### PR DESCRIPTION
基本可用

## Summary by Sourcery

Integrate Claudix-specific configuration and settings UI into the JetBrains plugin and wire it through the configuration and RPC layers.

New Features:
- Add IDE settings page for configuring Claudix model selection and environment variables, persisted via an application-level ClaudixSettings service.
- Expose commands to open settings, reveal files in the system explorer, and debug Claudix configuration from the editor API.
- Include Claudix configuration in the extension host initialization payload and propagate configuration changes via acceptConfigurationChanged.

Enhancements:
- Route claudix.* configuration updates through a dedicated handler that syncs to both ClaudixSettings and PropertiesComponent.
- Register the Claudix settings configurable in plugin.xml so it appears under Tools in the settings dialog.
- Switch the default VSCode plugin used by the JetBrains wrapper from roo-code to claudix.

Build:
- Change the JetBrains plugin build configuration to default the vscodePlugin property to "claudix" instead of "roo-code".
- Adjust the extension host build script to build the extension via tsup without running tsc --noEmit, and add a TypeScript dev dependency.